### PR TITLE
fix: incorrect compiler options on riscv

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+rapidjson (1.1.0+dfsg2-7.4deepin1) unstable; urgency=medium
+
+  * Do not use -march=native on riscv32 and riscv64.
+  * Disable -Werror=class-memaccess.
+
+ -- sisungo <sisungo@icloud.com>  Sat, 6 Sep 2025 10:23:21 +0800
+
 rapidjson (1.1.0+dfsg2-7.4) unstable; urgency=medium
 
   * Non-maintainer upload.

--- a/debian/patches/0001-deal-with-werror-class-memaccess.patch
+++ b/debian/patches/0001-deal-with-werror-class-memaccess.patch
@@ -1,0 +1,25 @@
+From e026965e4a0c0c18628a53ffe4a8af8a6d25779f Mon Sep 17 00:00:00 2001
+From: sisungo <sisungo@icloud.com>
+Date: Sat, 6 Sep 2025 09:49:31 +0800
+Subject: [PATCH] deal with werror class-memaccess
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 23df6b2..2898a49 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,7 +58,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+     endif()
+     endif()
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-error=class-memaccess")
+     if (RAPIDJSON_BUILD_CXX11)
+         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7.0")
+             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+-- 
+2.50.1
+

--- a/debian/patches/0001-support-RISC-V-compiler.patch
+++ b/debian/patches/0001-support-RISC-V-compiler.patch
@@ -1,0 +1,25 @@
+From 1b00eeb7d89a31c88f3eb6a8c95e7d0466be1512 Mon Sep 17 00:00:00 2001
+From: sisungo <sisungo@icloud.com>
+Date: Sat, 6 Sep 2025 09:21:07 +0800
+Subject: [PATCH] support RISC-V compiler
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9cbc796..23df6b2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -53,7 +53,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+     if(NOT CMAKE_CROSSCOMPILING)
+     if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "powerpc" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "ppc64" OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "ppc64le")
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
+-    else()
++    elseif(NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "riscv32" AND NOT ${CMAKE_SYSTEM_PROCESSOR} STREQUAL "riscv64")
+       #FIXME: x86 is -march=native, but doesn't mean every arch is this option. To keep original project's compatibility, I leave this except POWER.
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+     endif()
+-- 
+2.50.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,6 +9,8 @@ gcc7.diff
 python3.diff
 0001-support-IBM-PowerPC-ppc64-ppc64le-and-XL-compiler.patch
 0001-CMake-do-not-pass-march-native-or-mcpu-native-when-c.patch
+0001-support-RISC-V-compiler.patch
+0001-deal-with-werror-class-memaccess.patch
 deal-with-Werror-type-limits.patch
 gcc12_encdedstreamtest.patch
 gcc12_valuetest.patch


### PR DESCRIPTION
On RISC-V, `-march=native` and `-mcpu=native` are not permitted, and this package generates "class-memaccess" warnings, which are treated as errors. This PR adds patches to solve the problems above.